### PR TITLE
add optional support for QUAY_USERNAME and QUAY_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The other minimal entrypoints required are
 - `bats_version`: BATS version ("1.5.0")
 - `envsubst_needed`: Indicate if envsubst is needed (default: "false")
 - `taskfile_name`: Name of the taskfile task to be executed (default: "test")
+- `quay_username`: quay Username
+- `quay_password`: quay Password
 
 ## Example workflow
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,14 @@ inputs:
     description: Name of the taskfile task to be executed
     required: false
     default: "test"
+  quay_username:
+    description: quay Username
+    default: ""
+    required: false
+  quay_password:
+    description: quay Password
+    default: ""
+    required: false
 runs:
   using: "composite"
   steps:
@@ -89,6 +97,8 @@ runs:
         ARTIFACTORY_USERNAME: ${{ inputs.ARTIFACTORY_USERNAME }}
         ARTIFACTORY_PASSWORD: ${{ inputs.ARTIFACTORY_PASSWORD }}
         TASKFILE_NAME: ${{ inputs.taskfile_name }}
+        QUAY_USERNAME: ${{ inputs.QUAY_USERNAME }}
+        QUAY_PASSWORD: ${{ inputs.QUAY_PASSWORD }}
       run: task ${TASKFILE_NAME}
     - name: Clean up
       if: always()


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

## What's New?

since github now has a quay username and secret exported to all draios repos let's enable using it
