### PR TITLE
Remove deprecated node12 mig4/setup-bats action, add libraries cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,9 +95,14 @@ runs:
       with:
         python-version: '3.x'
     - name: Install Bats and bats libs
-      uses: brokenpip3/setup-bats-libs@1.0.0
+      #uses: brokenpip3/setup-bats-libs@1.5.0
+      uses: brokenpip3/setup-bats-libs@add-path-if-cache
       with:
         bats-version: ${{ inputs.bats_version }}
+        support-path: "${{ github.workspace }}/tests/bats-support"
+        assert-path: "${{ github.workspace }}/tests/bats-assert"
+        detik-path: "${{ github.workspace }}/tests/bats-detik"
+        file-path: "${{ github.workspace }}/tests/bats-file"
     - name: Setup envsubst
       if: ${{ inputs.envsubst_needed == 'true' }}
       shell: bash
@@ -138,6 +143,7 @@ runs:
     - name: Lint and tests
       shell: bash
       env:
+        BATS_LIB_PATH: "${{ github.workspace }}/tests"
         GITHUB_REF_NAME: ${{ github.ref }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         ARTIFACTORY_USERNAME: ${{ inputs.artifactory_username }}

--- a/action.yml
+++ b/action.yml
@@ -95,8 +95,7 @@ runs:
       with:
         python-version: '3.x'
     - name: Install Bats and bats libs
-      #uses: brokenpip3/setup-bats-libs@1.5.0
-      uses: brokenpip3/setup-bats-libs@add-path-if-cache
+      uses: brokenpip3/setup-bats-libs@1.5.1
       with:
         bats-version: ${{ inputs.bats_version }}
         support-path: "${{ github.workspace }}/.bats/bats-support"

--- a/action.yml
+++ b/action.yml
@@ -99,10 +99,10 @@ runs:
       uses: brokenpip3/setup-bats-libs@add-path-if-cache
       with:
         bats-version: ${{ inputs.bats_version }}
-        support-path: "${{ github.workspace }}/tests/bats-support"
-        assert-path: "${{ github.workspace }}/tests/bats-assert"
-        detik-path: "${{ github.workspace }}/tests/bats-detik"
-        file-path: "${{ github.workspace }}/tests/bats-file"
+        support-path: "${{ github.workspace }}/.bats/bats-support"
+        assert-path: "${{ github.workspace }}/.bats/bats-assert"
+        detik-path: "${{ github.workspace }}/.bats/bats-detik"
+        file-path: "${{ github.workspace }}/.bats/bats-file"
     - name: Setup envsubst
       if: ${{ inputs.envsubst_needed == 'true' }}
       shell: bash
@@ -143,7 +143,7 @@ runs:
     - name: Lint and tests
       shell: bash
       env:
-        BATS_LIB_PATH: "${{ github.workspace }}/tests"
+        BATS_LIB_PATH: "${{ github.workspace }}/.bats"
         GITHUB_REF_NAME: ${{ github.ref }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         ARTIFACTORY_USERNAME: ${{ inputs.artifactory_username }}

--- a/action.yml
+++ b/action.yml
@@ -94,12 +94,10 @@ runs:
       uses: actions/setup-python@v4.7.0
       with:
         python-version: '3.x'
-    - name: Setup BATS
-      uses: mig4/setup-bats@v1
+    - name: Install Bats and bats libs
+      uses: brokenpip3/setup-bats-libs@1.0.0
       with:
         bats-version: ${{ inputs.bats_version }}
-    - name: Setup BATS libs
-      uses: brokenpip3/setup-bats-libs@0.1.0
     - name: Setup envsubst
       if: ${{ inputs.envsubst_needed == 'true' }}
       shell: bash


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

## What's New?

* Removed the https://github.com/mig4/setup-bats action since node12 actions has been depreacted and also this action is not maintained (since 2-3 years)
* Install bats binary by using instead brokenpip3/setup-bats-libs (binary cached)
* Always run the libraries installation inside home, by doing that the bats-libraries can be cached as well (instead of `/usr/lib/bats-xxx` which is the default path for this action)

## Other info
close https://github.com/draios/infra-action-test-runner/pull/51