### PR TITLE
[SITEOPS-1422] add conditional artifactory, gar, and quay logins to test runner action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,6 +120,27 @@ runs:
         wait: ${{ inputs.kind_wait }}
         kubectl_version: ${{ inputs.kind_kubectl_version }}
         verbosity: ${{ inputs.kind_log_level }}
+    - name: Login to Artifactory
+      uses: docker/login-action@v2
+      if: ${{inputs.artifactory_username != '' && inputs.artifactory_password != '' }}
+      with:
+        registry: ${{ inputs.artifactory_url }}
+        username: ${{ inputs.artifactory_username }}
+        password: ${{ inputs.artifactory_password }}
+    - name: Login to Quay
+      uses: docker/login-action@v2
+      if: ${{inputs.quay_username != '' && inputs.quay_password != ''  }}
+      with:
+        registry: quay.io
+        username: ${{ inputs.quay_username }}
+        password: ${{ inputs.quay_password }}
+    - name: Login to GAR
+      uses: docker/login-action@v2
+      if: ${{inputs.gar_password != '' }}
+      with:
+        registry: ${{ inputs.gar_prefix }}
+        username: _json_key
+        password: ${{ inputs.gar_password }}
     - name: Download image artifact
       uses: actions/download-artifact@v4.1.4
       if: ${{ inputs.import_image_artifact == 'true' }}


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

[SITEOPS-1422](https://sysdig.atlassian.net/browse/SITEOPS-1422)

## What's New?

due to the new DoD stig ubi based images being private in quay we need to add conditional quay logins to the test runner action. for completeness add artifactory and gar since we're here and they are also conditional. this time with a signed commit

[SITEOPS-1422]: https://sysdig.atlassian.net/browse/SITEOPS-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ