### PR TITLE
[DEVOPS-14928] - revert kind/kubectl to versions that work on the utility cluster. add notes to action and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ The other minimal entrypoints required are
 - `import_image_artifact`: Boolean if the image artifact should be imported (default: false)
 - `kind_cluster_name`: KinD cluster name (default: kind)
 - `kind_config_path`: KinD config path (default: tests/kind-config.yaml)
-- `kind_kubectl_version`: the kubectl version to use with KinD (default: v1.29.14)
+- `kind_kubectl_version`: the kubectl version to use with KinD (default: v1.27.1) - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
 - `kind_log_level`: the KinD verbosity level (default: 0)
 - `kind_needed`: Boolean if a Kubernetes In Docker cluster is needed for tests (default: true)
-- `kind_version`: KinD version (default: "v0.27.0")
+- `kind_version`: KinD version (default: "v0.19.0") - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
 - `kind_wait`: increase the timeout for KinD to check if the control plane is ready (default: 60s)
 - `local_image_name`: Name of the image to be imported (default: "testimage:local")
 - `quay_password`: quay Password

--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,8 @@ inputs:
     description: KinD config path
     required: false
   kind_kubectl_version:
-    default: v1.27.1 - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
-    description: kubectl version to use with KinD
+    default: v1.27.1
+    description: kubectl version to use with KinD - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
     required: false
   kind_log_level:
     description: KinD verbosity to set

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
     description: KinD config path
     required: false
   kind_kubectl_version:
-    default: v1.29.14
+    default: v1.27.1 - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
     description: kubectl version to use with KinD
     required: false
   kind_log_level:
@@ -60,8 +60,8 @@ inputs:
     description: "Boolean if a Kubernetes In Docker cluster is needed for tests (default: true)"
     required: false
   kind_version:
-    default: "v0.27.0"
-    description: KinD version
+    default: "v0.19.0"
+    description: KinD version - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
     required: false
   kind_wait:
     default: 60s


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

[DEVOPS-14928](https://sysdig.atlassian.net/browse/DEVOPS-14928)

## What's New?

revert `kind`/`kubectl` to versions that work on the utility cluster. add notes to action and README

[DEVOPS-14928]: https://sysdig.atlassian.net/browse/DEVOPS-14928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ