### PR TITLE
feat!: [DEVOPS-14928] - update action to latest version of bats, kind, kubectl, etc.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -6,10 +6,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v5.0.0
     - uses: actions/setup-python@v5.6.0
       with:
-        python-version: '3.x'
+        python-version: '3.13'
     - uses: pre-commit/action@v3.0.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -20,7 +20,7 @@ jobs:
     outputs:
       net_tag: ${{ steps.tag_version.outputs.new_tag }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
@@ -31,7 +31,7 @@ jobs:
   test-action-default:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - uses: arduino/setup-task@v2
       - name: Test local action
         id: local-action
@@ -39,7 +39,7 @@ jobs:
   test-action-not-default:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - uses: arduino/setup-task@v2
       - name: Test local action
         id: local-action

--- a/.github/workflows/tag_and_build.yaml
+++ b/.github/workflows/tag_and_build.yaml
@@ -6,10 +6,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v5.0.0
     - uses: actions/setup-python@v5.6.0
       with:
-        python-version: '3.x'
+        python-version: '3.13'
     - uses: pre-commit/action@v3.0.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -20,7 +20,7 @@ jobs:
     outputs:
       next_tag: ${{ steps.tag_version.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The other minimal entrypoints required are
 ## Optional
 
 - `artifact_name`: Name of the artifact to be downloaded and imported (default: "image")
-- `bats_version`: BATS version (default: "1.11.1")
+- `bats_version`: BATS version (default: "1.12.0")
 - `envsubst_needed`: Indicate if envsubst is needed (default: "false")
 - `gar_password`: GAR Password
 - `gar_registry`: GAR Registry
@@ -31,10 +31,10 @@ The other minimal entrypoints required are
 - `import_image_artifact`: Boolean if the image artifact should be imported (default: false)
 - `kind_cluster_name`: KinD cluster name (default: kind)
 - `kind_config_path`: KinD config path (default: tests/kind-config.yaml)
-- `kind_kubectl_version`: the kubectl version to use with KinD (default: v1.27.1) - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
+- `kind_kubectl_version`: the kubectl version to use with KinD (default: v1.33.4)
 - `kind_log_level`: the KinD verbosity level (default: 0)
 - `kind_needed`: Boolean if a Kubernetes In Docker cluster is needed for tests (default: true)
-- `kind_version`: KinD version (default: "v0.19.0") - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
+- `kind_version`: KinD version (default: "v0.30.0")
 - `kind_wait`: increase the timeout for KinD to check if the control plane is ready (default: 60s)
 - `local_image_name`: Name of the image to be imported (default: "testimage:local")
 - `quay_password`: quay Password
@@ -57,8 +57,8 @@ jobs:
   tests:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: draios/infra-action-test-runner@v1.3
+      - uses: actions/checkout@v5.0.0
+      - uses: draios/infra-action-test-runner@v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # this will trigger `task test` in the target repo

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Name of the artifact to be downloaded and imported
     required: false
   bats_version:
-    default: "1.11.1"
+    default: "1.12.0"
     description: "BATS version"
     required: false
   envsubst_needed:
@@ -48,7 +48,7 @@ inputs:
     description: KinD config path
     required: false
   kind_kubectl_version:
-    default: v1.27.1
+    default: v1.33.4
     description: kubectl version to use with KinD - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
     required: false
   kind_log_level:
@@ -60,7 +60,7 @@ inputs:
     description: "Boolean if a Kubernetes In Docker cluster is needed for tests (default: true)"
     required: false
   kind_version:
-    default: "v0.19.0"
+    default: "v0.30.0"
     description: KinD version - this version cannot be updated until the utility cluster has been updated - DEVOPS-14991
     required: false
   kind_wait:
@@ -85,7 +85,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v5.6.0
       with:
-        python-version: "3.x"
+        python-version: '3.13'
     - name: Install Bats and bats libs
       uses: bats-core/bats-action@3.0.1
       with:
@@ -104,9 +104,9 @@ runs:
     - name: Setup Taskfile
       uses: arduino/setup-task@v2
     - name: Setup Helm
-      uses: azure/setup-helm@v4.3.0
+      uses: azure/setup-helm@v4.3.1
       with:
-        version: 'v3.17.3'
+        version: 'v3.18.6'
     - name: Setup KinD
       if: ${{ inputs.kind_needed == 'true' }}
       uses: helm/kind-action@v1.12.0
@@ -118,21 +118,21 @@ runs:
         version: ${{ inputs.kind_version }}
         wait: ${{ inputs.kind_wait }}
     - name: Login to Quay
-      uses: docker/login-action@v3
+      uses: docker/login-action@v3.5.0
       if: ${{inputs.quay_username != '' && inputs.quay_password != ''  }}
       with:
         password: ${{ inputs.quay_password }}
         registry: quay.io
         username: ${{ inputs.quay_username }}
     - name: Login to GAR
-      uses: docker/login-action@v3
+      uses: docker/login-action@v3.5.0
       if: ${{inputs.gar_username != '' && inputs.gar_password != '' }}
       with:
         password: ${{ inputs.gar_password }}
         registry: ${{ inputs.gar_registry }}
         username: ${{ inputs.gar_username }}
     - name: Download image artifact
-      uses: actions/download-artifact@v4.3.0
+      uses: actions/download-artifact@v5.0.0
       if: ${{ inputs.import_image_artifact == 'true' }}
       with:
         name: ${{ inputs.artifact_name }}


### PR DESCRIPTION
BREAKING CHANGE: major update of kind/kubectl versions

# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

[DEVOPS-14928](https://sysdig.atlassian.net/browse/DEVOPS-14928)

## What's New?
now that [DEVOPS-14991](https://sysdig.atlassian.net/browse/DEVOPS-14991) is completed we can update `infra-action-test-runner` to the latest version of `bats`, `kind`, `kubectl`, etc.

[DEVOPS-14928]: https://sysdig.atlassian.net/browse/DEVOPS-14928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEVOPS-14991]: https://sysdig.atlassian.net/browse/DEVOPS-14991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ